### PR TITLE
Update sorting of results

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -110,7 +110,7 @@ def SeedJSON(url, title, season, show_title):
         ))
         
     # For some reason the json is being sorted out of order so we have to sort it here
-    oc.objects.sort(key = lambda obj: obj.index, reverse=True)
+    oc.objects.sort(key = lambda obj: obj.index, reverse=False)
         
     if len(oc) < 1:
         Log ('still no value for objects')


### PR DESCRIPTION
Seasons and videos all end up in descending order, which causes issues when attempting to watch seasons in episode order. Changing sort order from reverse to !reverse should fix the issue.